### PR TITLE
inpl: create positivery docker network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: db
+DOCKER:=`which docker`
 DOCKER_COMPOSE:=`which docker-compose`
 DOCKER_COMPOSE_FILE:='-f docker-compose.yml'
 
@@ -13,3 +14,6 @@ db:
 
 api_test:
 	curl localhost:8080/api/hello
+
+init:
+	$(DOCKER) network create -d bridge positivery


### PR DESCRIPTION
ref #29 

netowork名は明示的に作ったものを利用した方がいいよね。